### PR TITLE
docker-compose config check improvements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     hooks:
       - id: docker-compose-check
         name: Check docker-compose files
-        entry: /compose-check.sh
+        entry: /usr/local/bin/compose-check.sh
         verbose: true
         language: script
         files: 'docker-compose.*\.ya?ml'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         entry: /usr/local/bin/compose-check.sh
         verbose: true
         language: script
-        files: 'docker-compose.*\.ya?ml'
+        files: 'docker-compose\.ya?ml'
   - repo: local
     hooks:
       - id: shellcheck

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM petzi/pre-commit:1.15.2-9
 COPY requirements.txt /
 RUN pip3 install --no-cache-dir -r requirements.txt
 COPY .pre-commit-config.yaml /
-COPY compose-check.sh /
+COPY compose-check.sh /usr/local/bin/
 COPY --from=koalaman/shellcheck:v0.6.0 /bin/shellcheck /usr/local/bin/
 COPY --from=mvdan/shfmt:v2.6.4 /bin/shfmt /usr/local/bin/

--- a/test/docker-compose.override.invalid.yml
+++ b/test/docker-compose.override.invalid.yml
@@ -1,0 +1,5 @@
+---
+version: '3.4'
+
+services:
+  myinvalidservice:


### PR DESCRIPTION
Improve handling of docker-compose checks:

1. Move the shell script to /usr/local/bin
2. Only check files that have a name of 'docker-compose.y(a)ml'

Other file names will be ignored, as they might contain invalid syntax (by design).